### PR TITLE
﻿Add Chat-type generation support

### DIFF
--- a/Extending.md
+++ b/Extending.md
@@ -32,6 +32,6 @@ The main Player and Room models will be generated, but there may be other supple
 
 ### Engine
 
-The Engine is what uses the Client API you defined above and uses GPT-3 (or any other service provided via `ICompletionService`) to play the game.
+The Engine is what uses the Client API you defined above and uses GPT (or any other service provided via `ICompletionService`) to play the game.
 
-With `ICompletionService` you can provide the prompt, any GPT-3 parameters you want, a set of conditions for a valid response, and how many times it should try to get a valid response before giving up. You can find examples in `src/Engines/BaseFibbageEngine.cs`, such as within the function `ProvideLie`.
+With `ICompletionService` you can provide the prompt, any GPT parameters you want, a set of conditions for a valid response, and how many times it should try to get a valid response before giving up. You can find examples in `src/Engines/BaseFibbageEngine.cs`, such as within the function `ProvideLie`.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # JackboxGPT
 
-Because we wanted to use AI for party games instead of "useful" things.
+Because everyone wants to use AI for party games instead of "useful" things, right?
 
-This project is a Jackbox client controlled by GPT-3 (note: this is a pre-ChatGPT model). It currently supports these games:
+This project is a Jackbox client controlled by OpenAI's GPT models. It currently supports these games:
 
-- Fibbage XL/2/3/4
-- Quiplash XL/2/3
 - Blather 'Round
+- Fibbage XL/2/3/4
 - Joke Boat
+- Quiplash XL/2/3
 - Survey Scramble _(all modes besides Bounce)_
-- Survive the Internet _(currently chooses images/votes randomly)_
-- Word Spud _(currently always votes positively)_
+- Survive the Internet
+- Word Spud
 
 ## Usage
 
@@ -24,14 +24,14 @@ See [this guide](Extending.md) for some information on adding support for more g
 
 ## FAQ
 
-- "Why GPT-3 specifically and not ChatGPT or another newer model?"
-> Mostly because this project was created before ChatGPT existed, and also because I have a preference for the older models. Adding support for newer models as an option is something I'll probably look into in the future though.
+- "What model types are supported?"
+> This project was created before ChatGPT existed, so the original implementation used Completion models only. It now supports Chat models as well, and there are options to use either type or a mix of both.
 
-- "How well does GPT-3 perform in Jackbox games?"
-> For normal prompts/answers it does a pretty decent job (by my standards), giving a mix of answers in a range from simple/boring to wild/outlandish. Some of the games also make requests for voting on answers though, which the AI isn't any good at (newer models would be better for that particular use case).
+- "How well do the Chat models work in Jackbox games?"
+> Pretty well, unsurprisingly. The one area they do stuggle in is variety. Since these model types are "smarter" they have a tendency to want to generate the same responses to equivalent prompts. This is especially prevalent in games with multiple AI players, as they may all end up generating the same or similar responses. There has been an effort to nudge the AI to try to minimize this, but it will still occur at least sometimes. In the future I may look into an 'overseer' module to track AI instances to make sure they don't duplicate answers, if configured to.
 
-- "How 'behaved' is GPT-3 in Jackbox games?"
-> Currently the actual wordage of AI responses are sent to the game unfiltered (punctuation and formatting are cleaned up), so any garbage that GPT-3 might generate would come through into the game. I don't know how filtered the AI is on OpenAI's side, but rarely there are some really unfun answers that make their way into responses, so just be aware of that.
+- "How well do the Completion models work in Jackbox games?"
+> For normal prompts/answers they do a decent job for what they are, giving a mix of answers in a range from simple/boring to wild/outlandish. These models are less adept at things like voting on answers though, unsurprisingly, but it's possible to configure the program to use a Chat model for this type of prompt specifically. Please note that Completion models are somewhat more chaotic than Chat models, so rarely there will likely be really unfun answers that make their way into Completion responses.
 
 - "Can the AI play without human players?"
 > This is possible for any game that has "Start Game from Controller Only" option (Party Pack 3+).

--- a/src/Engines/BaseJackboxEngine.cs
+++ b/src/Engines/BaseJackboxEngine.cs
@@ -18,7 +18,11 @@ namespace JackboxGPT.Engines
         private readonly ILogger _logger;
 
         protected const int BASE_INSTANCE = 1;
+        protected const string BASE_INSTANCE_NAME = "System";
         protected readonly int Instance = BASE_INSTANCE;
+        protected readonly string InstanceName = "Client";
+
+        protected bool UseChatEngine = false;
 
         protected BaseJackboxEngine(ICompletionService completionService, ILogger logger, TClient client)
         {
@@ -34,42 +38,47 @@ namespace JackboxGPT.Engines
             _logger = logger;
             Instance = instance;
             Config = configFile;
+            InstanceName = $"{configFile.General.PlayerName}-{instance}";
         }
 
         // ReSharper disable UnusedMember.Global
-        protected void LogWarning(string text, bool onlyOnce = false, string prefix = "")
-        {
-            if (onlyOnce && Instance != BASE_INSTANCE) return;
-            var client = $"client{(onlyOnce ? "s" : Instance.ToString())}";
-            _logger.ForContext("Prefix", prefix).Warning($"[{Tag}][{client}] {text}");
-        }
-
         protected void LogError(string text, bool onlyOnce = false, string prefix = "")
         {
             if (onlyOnce && Instance != BASE_INSTANCE) return;
-            var client = $"client{(onlyOnce ? "s" : Instance.ToString())}";
-            _logger.ForContext("Prefix", prefix).Error($"[{Tag}][{client}] {text}");
+
+            var name = onlyOnce ? BASE_INSTANCE_NAME : InstanceName;
+            _logger.ForContext("Prefix", prefix).Error($"[{{P1}}][{{P2}}] {text}", Tag, name);
+        }
+
+        protected void LogWarning(string text, bool onlyOnce = false, string prefix = "")
+        {
+            if (onlyOnce && Instance != BASE_INSTANCE) return;
+
+            var name = onlyOnce ? BASE_INSTANCE_NAME : InstanceName;
+            _logger.ForContext("Prefix", prefix).Warning($"[{{P1}}][{{P2}}] {text}", Tag, name);
+        }
+        protected void LogInfo(string text, bool onlyOnce = false, string prefix = "")
+        {
+            if (onlyOnce && Instance != BASE_INSTANCE) return;
+
+            var name = onlyOnce ? BASE_INSTANCE_NAME : InstanceName;
+            _logger.ForContext("Prefix", prefix).Information($"[{{P1}}][{{P2}}] {text}", Tag, name);
         }
 
         protected void LogDebug(string text, bool onlyOnce = false, string prefix = "")
         {
             if (onlyOnce && Instance != BASE_INSTANCE) return;
-            var client = $"client{(onlyOnce ? "s" : Instance.ToString())}";
-            _logger.ForContext("Prefix", prefix).Debug($"[{Tag}][{client}] {text}");
+
+            var name = onlyOnce ? BASE_INSTANCE_NAME : InstanceName;
+            _logger.ForContext("Prefix", prefix).Debug($"[{{P1}}][{{P2}}] {text}", Tag, name);
         }
 
         protected void LogVerbose(string text, bool onlyOnce = false, string prefix = "")
         {
             if (onlyOnce && Instance != BASE_INSTANCE) return;
-            var client = $"client{(onlyOnce ? "s" : Instance.ToString())}";
-            _logger.ForContext("Prefix", prefix).Verbose($"[{Tag}][{client}] {text}");
-        }
 
-        protected void LogInfo(string text, bool onlyOnce = false, string prefix = "")
-        {
-            if (onlyOnce && Instance != BASE_INSTANCE) return;
-            var client = $"client{(onlyOnce ? "s" : Instance.ToString())}";
-            _logger.ForContext("Prefix", prefix).Information($"[{Tag}][{client}] {text}");
+            var name = onlyOnce ? BASE_INSTANCE_NAME : InstanceName;
+            _logger.ForContext("Prefix", prefix).Verbose($"[{{P1}}][{{P2}}] {text}", Tag, name);
         }
         // ReSharper restore UnusedMember.Global
     }

--- a/src/Engines/Fibbage1Engine.cs
+++ b/src/Engines/Fibbage1Engine.cs
@@ -10,7 +10,7 @@ namespace JackboxGPT.Engines
     {
         protected override string Tag => "fibbage";
         
-        public Fibbage1Engine(ICompletionService completionService, ILogger logger, Fibbage2Client client, ManagedConfigFile configFile, int instance)
-            : base(completionService, logger, client, configFile, instance) { }
+        public Fibbage1Engine(ICompletionService completionService, ILogger logger, Fibbage2Client client, ManagedConfigFile configFile, int instance, uint coinFlip)
+            : base(completionService, logger, client, configFile, instance, coinFlip) { }
     }
 }

--- a/src/Engines/Fibbage2Engine.cs
+++ b/src/Engines/Fibbage2Engine.cs
@@ -12,8 +12,8 @@ namespace JackboxGPT.Engines
     {
         protected override string Tag => "fibbage2";
         
-        public Fibbage2Engine(ICompletionService completionService, ILogger logger, Fibbage2Client client, ManagedConfigFile configFile, int instance)
-            : base(completionService, logger, client, configFile, instance)
+        public Fibbage2Engine(ICompletionService completionService, ILogger logger, Fibbage2Client client, ManagedConfigFile configFile, int instance, uint coinFlip)
+            : base(completionService, logger, client, configFile, instance, coinFlip)
         {
             JackboxClient.OnRoomUpdate += OnRoomUpdate;
             JackboxClient.OnSelfUpdate += OnSelfUpdate;
@@ -58,8 +58,7 @@ namespace JackboxGPT.Engines
                 LieLock = TruthLock = false;
             }
         }
-        
-        #region Game Actions
+
         private async void SubmitLie()
         {
             var lie = await FormLie(JackboxClient.GameState.Room.Question);
@@ -94,9 +93,7 @@ namespace JackboxGPT.Engines
 
             JackboxClient.ChooseBloop(choices[category].Id);
         }
-        #endregion
 
-        #region Prompt Cleanup
         protected override string GetDefaultLie()
         {
             var choices = JackboxClient.GameState.Self.SuggestionChoices;
@@ -108,6 +105,5 @@ namespace JackboxGPT.Engines
 
             return choices[choices.RandomIndex()];
         }
-        #endregion
     }
 }

--- a/src/Engines/Fibbage3Engine.cs
+++ b/src/Engines/Fibbage3Engine.cs
@@ -20,8 +20,8 @@ namespace JackboxGPT.Engines
         // Fibbage 3 sends suggestions in a follow up which messes up the usual logic
         private List<string> _suggestionsRef;
 
-        public Fibbage3Engine(ICompletionService completionService, ILogger logger, Fibbage3Client client, ManagedConfigFile configFile, int instance)
-            : base(completionService, logger, client, configFile, instance)
+        public Fibbage3Engine(ICompletionService completionService, ILogger logger, Fibbage3Client client, ManagedConfigFile configFile, int instance, uint coinFlip)
+            : base(completionService, logger, client, configFile, instance, coinFlip)
         {
             JackboxClient.OnRoomUpdate += OnRoomUpdate;
             JackboxClient.OnSelfUpdate += OnSelfUpdate;
@@ -87,8 +87,7 @@ namespace JackboxGPT.Engines
             if (revision.Old.State != revision.New.State)
                 LogDebug($"New room state: {room.State}", true);
         }
-        
-        #region Game Actions
+
         private async void SubmitLie(Fibbage3Player self)
         {
             var lie = await FormLie(self.Question, self.MaxLength);
@@ -128,9 +127,6 @@ namespace JackboxGPT.Engines
 
             JackboxClient.ChooseCategory(category);
         }
-        #endregion
-
-        #region Prompt Cleanup
 
         protected override string GetDefaultLie()
         {
@@ -164,6 +160,5 @@ namespace JackboxGPT.Engines
 
             return new Tuple<string, string>(parts[0], parts[1]);
         }
-        #endregion
     }
 }

--- a/src/Engines/Quiplash1Engine.cs
+++ b/src/Engines/Quiplash1Engine.cs
@@ -11,8 +11,8 @@ namespace JackboxGPT.Engines
     {
         protected override string Tag => "quiplash";
 
-        public Quiplash1Engine(ICompletionService completionService, ILogger logger, Quiplash1Client client, ManagedConfigFile configFile, int instance)
-            : base(completionService, logger, client, configFile, instance)
+        public Quiplash1Engine(ICompletionService completionService, ILogger logger, Quiplash1Client client, ManagedConfigFile configFile, int instance, uint coinFlip)
+            : base(completionService, logger, client, configFile, instance, coinFlip)
         {
             JackboxClient.OnSelfUpdate += OnSelfUpdate;
             JackboxClient.OnRoomUpdate += OnRoomUpdate;

--- a/src/Engines/SurviveTheInternetEngine.cs
+++ b/src/Engines/SurviveTheInternetEngine.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using JackboxGPT.Extensions;
@@ -8,6 +10,7 @@ using JackboxGPT.Games.SurviveTheInternet;
 using JackboxGPT.Games.SurviveTheInternet.Models;
 using JackboxGPT.Services;
 using Serilog;
+using static JackboxGPT.Services.ICompletionService;
 
 namespace JackboxGPT.Engines
 {
@@ -16,14 +19,17 @@ namespace JackboxGPT.Engines
         protected override string Tag => "survivetheinternet";
 
         private readonly ImageDescriptionProvider _descriptionProvider;
-        private readonly IConfigurationProvider _configuration;
 
-        public SurviveTheInternetEngine(ICompletionService completionService, ILogger logger, IConfigurationProvider configuration,
-            SurviveTheInternetClient client, ManagedConfigFile configFile, int instance) : base(completionService, logger, client, configFile, instance)
+        public SurviveTheInternetEngine(ICompletionService completionService, ILogger logger, SurviveTheInternetClient client, ManagedConfigFile configFile, int instance, uint coinFlip)
+            : base(completionService, logger, client, configFile, instance)
         {
-            _configuration = configuration;
+            UseChatEngine = configFile.SurviveTheInternet.EnginePreference == ManagedConfigFile.EnginePreference.Chat
+                            || (configFile.SurviveTheInternet.EnginePreference == ManagedConfigFile.EnginePreference.Mix && instance % 2 == coinFlip);
+            LogDebug($"Using {(UseChatEngine ? "Chat" : "Completion")} engine");
+            CompletionService.ResetAll();
+
             _descriptionProvider = new ImageDescriptionProvider("sti_image_descriptions.json");
-            
+
             JackboxClient.OnSelfUpdate += OnSelfUpdate;
             JackboxClient.Connect();
         }
@@ -51,9 +57,12 @@ namespace JackboxGPT.Engines
             JackboxClient.ChooseIndex(choice);
         }
 
-        private void SubmitVote(SurviveTheInternetPlayer player)
+        private async void SubmitVote(SurviveTheInternetPlayer player)
         {
-            var vote = player.EntryChoices.RandomIndex();
+            var entries = player.EntryChoices.Select(c => $"{c.Header}\n{c.Body}\n{c.Footer}").ToList();
+            var vote = await ProvideVote(entries);
+
+            LogDebug($"Choosing \"{entries[vote]}\"");
             JackboxClient.ChooseIndex(vote);
         }
 
@@ -75,11 +84,40 @@ namespace JackboxGPT.Engines
 
             JackboxClient.SendEntry(entry);
         }
-        
-        #region GPT-3 Prompts
+
+        private string CleanResult(string input, bool logChanges = false)
+        {
+            // AI likes to self censor sometimes
+            if (input.Contains("**")) return "";
+
+            var clipped = input.ToUpper();
+            if (input.Contains('#'))
+                clipped = input[..clipped.IndexOf('#')];
+
+            // Characters that shouldn't be in a submitted answer
+            var removals = new[] { "\n", "\r", "\t"};
+            foreach (var r in removals)
+                clipped = clipped.Replace(r, null);
+
+            // Characters that shouldn't be on the front or back of a submitted answer  (AI really likes using !)
+            var endRemovals = new[] { '.', ' ', ',', '"', '!' };
+            clipped = clipped.Trim(endRemovals);
+
+            // Remove any double spaces that previous changes may have created
+            clipped = clipped.Trim().Replace("  ", " ");
+
+            if (logChanges && input.Length != clipped.Length)
+                LogDebug($"Edited AI response from \"{input.ToUpper()}\" to \"{clipped}\"");
+            return clipped;
+        }
+
         private async Task<string> ProvideResponse(string stiPrompt, int maxLength)
         {
-            var prompt = $@"In the first part of the game Survive the Internet, players are asked questions which they should answer short and concisely. For example:
+            var prompt = new TextInput
+            {
+                ChatSystemMessage = "You are a player in a game called Survive the Internet, in which players attempt to create silly posts that might appear on the internet. You'll be evaluated against other players, so try to be original. Please respond to the prompt with only your concise answer. Please do not use emoji.",
+                ChatStylePrompt = $"Here's a new prompt: {stiPrompt}",
+                CompletionStylePrompt = $@"In the first part of the game Survive the Internet, players are asked questions which they should answer short and concisely. For example:
 
 Q: How's your retirement fund doing?
 A: It's nonexistant.
@@ -91,28 +129,40 @@ Q: Describe an attitude you admire.
 A: I love positive people.
 
 Q: {stiPrompt}
-A:";
-            
-            LogVerbose($"GPT-3 Prompt: {prompt}");
-            
-            var result = await CompletionService.CompletePrompt(prompt, new ICompletionService.CompletionParameters
+A:",
+            };
+            LogVerbose($"Prompt:\n{(UseChatEngine ? prompt.ChatStylePrompt : prompt.CompletionStylePrompt)}");
+
+            var result = await CompletionService.CompletePrompt(prompt, UseChatEngine, new CompletionParameters
                 {
                     Temperature = Config.SurviveTheInternet.GenTemp,
                     MaxTokens = 32,
-                    TopP = 1,
                     FrequencyPenalty = 0.3,
                     PresencePenalty = 0.2,
                     StopSequences = new[] { "\n" }
-                }, completion => completion.Text.Length <= maxLength,
+                },
+                completion =>
+                {
+                    var cleanText = CleanResult(completion.Text.Trim());
+                    if (cleanText.Length > 0 && cleanText.Length <= maxLength && !cleanText.Contains(stiPrompt.ToUpper().Trim()))
+                        return true;
+
+                    LogDebug($"Received unusable ProvideResponse response: \"{completion.Text.Trim()}\"");
+                    return false;
+                },
                 maxTries: Config.SurviveTheInternet.MaxRetries,
                 defaultResponse: "Default response");
 
-            return result.Text.Trim().TrimQuotes().TrimEnd('.');
+            return CleanResult(result.Text.Trim());
         }
         
         private async Task<string> ProvideTwist(TextPrompt stiPrompt, int maxLength)
         {
-            var prompt = $@"Below are some responses from the party game Survive the Internet. The goal of this game is to take another player's words and twist them to make the other player look ridiculous.
+            var prompt = new TextInput
+            {
+                ChatSystemMessage = "You are a player in a game called Survive the Internet, in which players attempt to create silly posts that might appear on the internet. You'll be evaluated against other players, so try to be original. Please respond to the prompt with only your concise answer. Please do not use emoji.",
+                ChatStylePrompt = $"Here's a new prompt: \"{stiPrompt.BlackBox}\" {stiPrompt.BelowBlackBox.ToLower().Trim()}",
+                CompletionStylePrompt = $@"Below are some responses from the party game Survive the Internet. The goal of this game is to take another player's words and twist them to make the other player look ridiculous.
 
 ""I'm skeptical"" would be a ridiculous response to this comment: She said yes!
 ""Too much nudity"" would be a ridiculous comment to a video titled: How to Play Guitar
@@ -121,55 +171,142 @@ A:";
 ""Let's hunt him down"" would be a terrible comment in response to this news headline: Local Man Wins Lottery
 ""Not that impressive tbh"" would be a ridiculous comment to a video titled: Johnny Learns How to Ride a Bike!
 ""It's not the most comfortable thing to sit on"" would be a ridiculous review for a product called: 18-inch Wooden Spoon
-""{stiPrompt.BlackBox}"" {stiPrompt.BelowBlackBox.ToLower().Trim()}";
-            
-            LogVerbose($"GPT-3 Prompt: {prompt}");
-            
-            var result = await CompletionService.CompletePrompt(prompt, new ICompletionService.CompletionParameters
+""{stiPrompt.BlackBox}"" {stiPrompt.BelowBlackBox.ToLower().Trim()}",
+            };
+            LogVerbose($"Prompt:\n{(UseChatEngine ? prompt.ChatStylePrompt : prompt.CompletionStylePrompt)}");
+
+            var result = await CompletionService.CompletePrompt(prompt, UseChatEngine, new CompletionParameters
                 {
                     Temperature = Config.SurviveTheInternet.GenTemp,
                     MaxTokens = 32,
-                    TopP = 1,
                     FrequencyPenalty = 0.3,
                     PresencePenalty = 0.2,
                     StopSequences = new[] { "\n" }
-                }, completion => completion.Text.Length <= maxLength,
+                },
+                completion =>
+                {
+                    var cleanText = CleanResult(completion.Text.Trim());
+                    if (cleanText.Length > 0 && cleanText.Length <= maxLength && !cleanText.Contains(stiPrompt.BelowBlackBox))
+                        return true;
+
+                    LogDebug($"Received unusable ProvideTwist response: \"{completion.Text.Trim()}\"");
+                    return false;
+                },
                 maxTries: Config.SurviveTheInternet.MaxRetries,
                 defaultResponse: "Default response");
 
-            return result.Text.Trim().TrimQuotes().TrimEnd('.');
+            return CleanResult(result.Text.Trim());
         }
         
         private async Task<string> ProvideImageTwist(TextPrompt stiPrompt, int maxLength)
         {
-            var isInstruct = _configuration.OpenAIEngine.EndsWith("-instruct-beta");
             var description = _descriptionProvider.ProvideDescriptionForImageId(GetImageId(stiPrompt));
 
-            // TODO rewrite, it is ugly :(
-            var prompt = isInstruct ?
-                $@"Write an absurd, weird, funny, ridiculous Instagram caption for a photo of {description}." :
-                $@"Below are some responses from the party game Survive the Internet. In the final round, each player takes an image and tries to come up with a caption that would make the other players look crazy or ridiculous.
+            var prompt = new TextInput
+            {
+                ChatSystemMessage = "You are a player in a game called Survive the Internet, in which players attempt to create silly posts that might appear on the internet. You'll be evaluated against other players, so try to be original. Please respond to the prompt with only your concise answer. Please do not use emoji.",
+                ChatStylePrompt = $"Here's a new prompt: An absurd and ridiculous Instagram caption for a photo of {description}:",
+                CompletionStylePrompt = $@"Below are some responses from the party game Survive the Internet. In the final round, each player takes an image and tries to come up with a caption that would make the other players look crazy or ridiculous.
 
 An absurd and ridiculous Instagram caption for a photo of a group of mailboxes, with one open: Learned how to lock pick earlier. Score!
 An absurd and ridiculous Instagram caption for a photo of people's legs through bathroom stalls: Just asked these guys how they were doing. They didn't respond.
 An absurd and ridiculous Instagram caption for a photo of a group of people posing for a photo at a funeral: Funeral? I thought this was a party.
-An absurd and ridiculous Instagram caption for a photo of {description}:";
-            
-            LogVerbose($"GPT-3 Prompt: {prompt}");
-            
-            var result = await CompletionService.CompletePrompt(prompt, new ICompletionService.CompletionParameters
+An absurd and ridiculous Instagram caption for a photo of {description}:",
+            };
+            LogVerbose($"Prompt:\n{(UseChatEngine ? prompt.ChatStylePrompt : prompt.CompletionStylePrompt)}");
+
+            var result = await CompletionService.CompletePrompt(prompt, UseChatEngine, new CompletionParameters
                 {
                     Temperature = Config.SurviveTheInternet.GenTemp,
                     MaxTokens = 32,
-                    TopP = 1,
                     FrequencyPenalty = 0.3,
                     PresencePenalty = 0.2,
-                    StopSequences = isInstruct ? Array.Empty<string>() : new[] { "\n" }
-                }, completion => completion.Text.Length <= maxLength,
+                    StopSequences = new[] { "\n" }
+                },
+                completion =>
+                {
+                    var cleanText = CleanResult(completion.Text.Trim());
+                    if (cleanText.Length > 0 && cleanText.Length <= maxLength && !cleanText.Contains(description.ToUpper()))
+                        return true;
+
+                    LogDebug($"Received unusable ProvideImageTwist response: \"{completion.Text.Trim()}\"");
+                    return false;
+                },
                 maxTries: Config.SurviveTheInternet.MaxRetries,
                 defaultResponse: "Default response");
 
-            return result.Text.Trim().TrimQuotes().TrimEnd('.');
+            return CleanResult(result.Text.Trim());
+        }
+
+        private async Task<int> ProvideVote(IReadOnlyList<string> entries)
+        {
+            var options = "";
+
+            for (var i = 0; i < entries.Count; i++)
+                options += $"{i + 1}. {entries[i]}\n";
+
+            var prompt = new TextInput
+            {
+                ChatSystemMessage = "You are a player in a game called Survive the Internet, in which players attempt to create silly posts that might appear on the internet. Please respond with only the number corresponding with the option that you think is the funniest post.",
+                ChatStylePrompt = options,
+                CompletionStylePrompt = $@"I was playing a game of Survive the Internet, and needed to choose my favorite funny post. My options were:
+
+{options}
+The funniest was post number: ",
+            };
+            LogVerbose($"Prompt:\n{(Config.Model.UseChatEngineForVoting ? prompt.ChatStylePrompt : prompt.CompletionStylePrompt)}");
+
+            int IntParseExt(string input)
+            {
+                if (input.Length < 1) throw new FormatException();
+
+                // Assume the response is int-parsable if it starts with a digit character
+                if (char.IsDigit(input[0])) return int.Parse(new string(input.TakeWhile(char.IsDigit).ToArray()));
+
+                // GPT likes to respond in English sometimes, so this (manually) tries to check for that
+                return input.ToUpper() switch
+                {
+                    "ONE" => 1,
+                    "TWO" => 2,
+                    "THREE" => 3,
+                    "FOUR" => 4,
+                    "FIVE" => 5,
+                    "SIX" => 6,
+                    "SEVEN" => 7,
+                    "EIGHT" => 8, // I don't know max options for StI
+                    _ => throw new FormatException() // Response was something unhandled here
+                };
+            }
+
+            var result = await CompletionService.CompletePrompt(prompt, Config.Model.UseChatEngineForVoting, new CompletionParameters
+            {
+                Temperature = Config.SurviveTheInternet.VoteTemp,
+                MaxTokens = 1,
+                StopSequences = new[] { "\n" }
+            }, completion =>
+            {
+                try
+                {
+                    var answer = IntParseExt(completion.Text.Trim());
+                    if (0 < answer && answer <= entries.Count) return true;
+                }
+                catch (FormatException)
+                {
+                    // pass
+                }
+
+                LogDebug($"Received unusable ProvideVote response: {completion.Text.Trim()}");
+                return false;
+            },
+                maxTries: Config.SurviveTheInternet.MaxRetries,
+                defaultResponse: "");
+
+            CompletionService.ResetOne(prompt.ChatSystemMessage);
+            if (result.Text != "")
+                return IntParseExt(result.Text.Trim()) - 1;
+
+            LogDebug("Received only unusable ProvideVote responses. Choice will be chosen randomly");
+            return new Random().Next(entries.Count);
         }
 
         private static string GetImageId(TextPrompt stiPrompt)
@@ -178,6 +315,5 @@ An absurd and ridiculous Instagram caption for a photo of {description}:";
             var match = Regex.Match(stiPrompt.AboveBlackBox, pattern);
             return match.Success ? match.Value : "Baseball.jpg"; // why not
         }
-        #endregion
     }
 }

--- a/src/Extensions/CollectionExtensions.cs
+++ b/src/Extensions/CollectionExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace JackboxGPT.Extensions
 {
@@ -10,6 +12,11 @@ namespace JackboxGPT.Extensions
         public static int RandomIndex(this ICollection collection)
         {
             return _random.Next(0, collection.Count);
+        }
+
+        public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> collection)
+        {
+            return collection.OrderBy(_ => _random.Next());
         }
     }
 }

--- a/src/Games/Common/BaseJackboxClient.cs
+++ b/src/Games/Common/BaseJackboxClient.cs
@@ -10,7 +10,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Serilog;
 using Websocket.Client;
-using Websocket.Client.Models;
 
 namespace JackboxGPT.Games.Common
 {
@@ -137,6 +136,8 @@ namespace JackboxGPT.Games.Common
 
         private void WsReceived(ResponseMessage msg)
         {
+            if (msg.Text == null) return;
+
             var srvMsg = JsonConvert.DeserializeObject<ServerMessage<JRaw>>(msg.Text);
             
             if (srvMsg.OpCode == OP_CLIENT_WELCOME)

--- a/src/JackboxGPT.csproj
+++ b/src/JackboxGPT.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.1.0" />
-    <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
+    <PackageReference Include="Autofac" Version="8.2.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OpenAI" Version="1.6.0" />
-    <PackageReference Include="dotenv.net" Version="2.1.3" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Tomlyn" Version="0.17.0" />
-    <PackageReference Include="Websocket.Client" Version="4.3.21" />
+    <PackageReference Include="OpenAI" Version="1.11.0" />
+    <PackageReference Include="dotenv.net" Version="3.2.1" />
+    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Tomlyn" Version="0.18.0" />
+    <PackageReference Include="Websocket.Client" Version="5.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -38,8 +38,8 @@ namespace JackboxGPT
                 Console.Write("New Room? [Y/N]: ");
                 var answer = Console.ReadLine() ?? "";
 
-                if (answer.ToUpper().StartsWith('Y')) return true;
-                if (answer.ToUpper().StartsWith('N')) return false;
+                if (answer.Trim().ToUpper() == "Y") return true;
+                if (answer.Trim().ToUpper() == "N") return false;
             }
         }
 
@@ -52,9 +52,10 @@ namespace JackboxGPT
             // Load entries from config file
             var conf = new CommandLineConfigurationProvider
             {
-                PlayerName = configFile.General.Name,
+                PlayerName = configFile.General.PlayerName,
                 LogLevel = configFile.General.LoggingLevel,
-                OpenAIEngine = configFile.General.Engine
+                OpenAICompletionEngine = configFile.Model.CompletionEngine,
+                OpenAIChatEngine = configFile.Model.ChatEngine
             };
 
 #if DEBUG
@@ -74,13 +75,19 @@ namespace JackboxGPT
 
         public static void Main(string[] args)
         {
-            DotEnv.AutoConfig();
+            DotEnv.Load();
             var configFile = LoadConfigFile("config.toml");
             var baseConfig = GetBaseConfig(args, configFile);
 
-            do
+            if (args.Length > 0)
             {
-                if (args.Length == 0) GetUserInput(baseConfig);
+                // CLI session
+                Startup.Bootstrap(baseConfig, configFile).Wait();
+            }
+            else do
+            {
+                // Interactive session
+                GetUserInput(baseConfig);
                 Startup.Bootstrap(baseConfig, configFile).Wait();
             } while (CheckEndOfService());
         }

--- a/src/Services/CommandLineConfigurationProvider.cs
+++ b/src/Services/CommandLineConfigurationProvider.cs
@@ -11,8 +11,11 @@ namespace JackboxGPT.Services
         [Option("name", Default = "GPT", HelpText = "The name the player should join the room as. The instance number of the client will be appended to this name (Name-#)")]
         public override string PlayerName { get; set; }
 
-        [Option("engine", Default = "davinci-002", HelpText = "The GPT-3 model to use for completions. Some game engines may use alternate models. Possible values: davinci-002, babbage-002")]
-        public override string OpenAIEngine { get; set; }
+        [Option("completion_engine", Default = "davinci-002", HelpText = "The GPT-3 model to use for completions. Possible values: davinci-002, babbage-002")]
+        public override string OpenAICompletionEngine { get; set; }
+
+        [Option("chat_engine", Default = "gpt-4o-mini", HelpText = "The ChatGPT model to use for chat completions. Possible values: gpt-4o-mini, gpt-4o, gpt-3.5-turbo-0125, etc")]
+        public override string OpenAIChatEngine { get; set; }
 
         [Option("verbosity", Default = "information", HelpText = "Log level to output. Possible values: verbose, debug, information, warning, error, fatal")]
         public override string LogLevel { get; set; }

--- a/src/Services/DefaultConfigurationProvider.cs
+++ b/src/Services/DefaultConfigurationProvider.cs
@@ -5,7 +5,8 @@
         public string EcastHost => "ecast.jackboxgames.com";
         
         public abstract string PlayerName { get; set; }
-        public abstract string OpenAIEngine { get; set; }
+        public abstract string OpenAICompletionEngine { get; set; }
+        public abstract string OpenAIChatEngine { get; set; }
         public abstract string RoomCode { get; set; }
         public abstract string LogLevel { get; set; }
         public abstract int WorkerCount { get; set; }

--- a/src/Services/ICompletionService.cs
+++ b/src/Services/ICompletionService.cs
@@ -9,9 +9,7 @@ namespace JackboxGPT.Services
     {
         public struct CompletionResponse
         {
-            [JsonProperty("text")]
             public string Text;
-            [JsonProperty("finish_reason")]
             public string FinishReason;
         }
 
@@ -35,6 +33,13 @@ namespace JackboxGPT.Services
             public string[] StopSequences;
         }
 
+        public struct TextInput
+        {
+            public string ChatSystemMessage;
+            public string ChatStylePrompt;
+            public string CompletionStylePrompt;
+        }
+
         public struct SearchResponse
         {
             public int Index;
@@ -42,7 +47,8 @@ namespace JackboxGPT.Services
         }
 
         public Task<CompletionResponse> CompletePrompt(
-            string prompt,
+            TextInput prompt,
+            bool chatCompletion,
             CompletionParameters completionParameters,
             Func<CompletionResponse, bool> conditions,
             int maxTries = 5,
@@ -50,7 +56,8 @@ namespace JackboxGPT.Services
         );
         
         public Task<T> CompletePrompt<T>(
-            string prompt,
+            TextInput prompt,
+            bool chatCompletion,
             CompletionParameters completionParameters,
             Func<CompletionResponse, T> process,
             T defaultResponse,
@@ -63,5 +70,8 @@ namespace JackboxGPT.Services
             IList<string> documents,
             int maxTries = 3
         );
+
+        public void ResetOne(string key);
+        public void ResetAll();
     }
 }

--- a/src/Services/IConfigurationProvider.cs
+++ b/src/Services/IConfigurationProvider.cs
@@ -8,7 +8,8 @@ namespace JackboxGPT.Services
         public string RoomCode { get; }
         public string LogLevel { get; }
         
-        public string OpenAIEngine { get; }
+        public string OpenAICompletionEngine { get; }
+        public string OpenAIChatEngine { get; }
         public int WorkerCount { get; }
     }
 }

--- a/src/Services/ManagedConfigFile.cs
+++ b/src/Services/ManagedConfigFile.cs
@@ -3,6 +3,7 @@
 public class ManagedConfigFile
 {
     public GeneralBlock General { get; set; }
+    public ModelBlock Model { get; set; }
     public BlatherRoundBlock BlatherRound { get; set; }
     public FibbageBlock Fibbage { get; set; }
     public JokeBoatBlock JokeBoat { get; set; }
@@ -14,6 +15,7 @@ public class ManagedConfigFile
     public ManagedConfigFile()
     {
         General = new GeneralBlock();
+        Model = new ModelBlock();
         BlatherRound = new BlatherRoundBlock();
         Fibbage = new FibbageBlock();
         JokeBoat = new JokeBoatBlock();
@@ -25,20 +27,40 @@ public class ManagedConfigFile
 
     public class GeneralBlock
     {
-        public string Name { get; set; }
+        public string PlayerName { get; set; }
         public string LoggingLevel { get; set; }  // verbose, debug, information, warning, error, fatal
-        public string Engine { get; set; }
 
         public GeneralBlock()
         {
-            Name = "GPT";
+            PlayerName = "GPT";
             LoggingLevel = "information";
-            Engine = "davinci-002";
         }
+    }
+
+    public class ModelBlock
+    {
+        public string CompletionEngine { get; set; }
+        public string ChatEngine { get; set; }
+        public bool UseChatEngineForVoting { get; set; }
+
+        public ModelBlock()
+        {
+            CompletionEngine = "davinci-002";
+            ChatEngine = "gpt-4o-mini";
+            UseChatEngineForVoting = true;
+        }
+    }
+
+    public enum EnginePreference
+    {
+        Completion,
+        Chat,
+        Mix
     }
 
     public class BlatherRoundBlock
     {
+        public EnginePreference EnginePreference { get; set; }
         public int MaxRetries { get; set; }
         public float GenTemp { get; set; }
         public int GuessDelayMinMs { get; set; }
@@ -50,6 +72,7 @@ public class ManagedConfigFile
 
         public BlatherRoundBlock()
         {
+            EnginePreference = EnginePreference.Chat;
             MaxRetries = 5;
             GenTemp = 0.7f;
             GuessDelayMinMs = 2000;
@@ -63,6 +86,7 @@ public class ManagedConfigFile
 
     public class FibbageBlock
     {
+        public EnginePreference EnginePreference { get; set; }
         public int MaxRetries { get; set; }
         public float GenTemp { get; set; }
         public float VoteTemp { get; set; }
@@ -71,6 +95,7 @@ public class ManagedConfigFile
 
         public FibbageBlock()
         {
+            EnginePreference = EnginePreference.Mix;
             MaxRetries = 5;
             GenTemp = 0.8f;
             VoteTemp = 0.8f;
@@ -81,6 +106,7 @@ public class ManagedConfigFile
 
     public class JokeBoatBlock
     {
+        public EnginePreference EnginePreference { get; set; }
         public int MaxRetries { get; set; }
         public float GenTemp { get; set; }
         public float VoteTemp { get; set; }
@@ -88,6 +114,7 @@ public class ManagedConfigFile
 
         public JokeBoatBlock()
         {
+            EnginePreference = EnginePreference.Mix;
             MaxRetries = 5;
             GenTemp = 0.7f;
             VoteTemp = 0.8f;
@@ -97,12 +124,14 @@ public class ManagedConfigFile
 
     public class QuiplashBlock
     {
+        public EnginePreference EnginePreference { get; set; }
         public int MaxRetries { get; set; }
         public float GenTemp { get; set; }
         public float VoteTemp { get; set; }
 
         public QuiplashBlock()
         {
+            EnginePreference = EnginePreference.Mix;
             MaxRetries = 5;
             GenTemp = 0.7f;
             VoteTemp = 0.8f;
@@ -147,6 +176,7 @@ public class ManagedConfigFile
             Random
         }
 
+        public EnginePreference EnginePreference { get; set; }
         public int MaxRetries { get; set; }
         public float GenTemp { get; set; }
         public float VoteTemp { get; set; }
@@ -171,6 +201,7 @@ public class ManagedConfigFile
 
         public SurveyScrambleBlock()
         {
+            EnginePreference = EnginePreference.Mix;
             MaxRetries = 4;
             GenTemp = 0.8f;
             VoteTemp = 0.7f;
@@ -196,27 +227,37 @@ public class ManagedConfigFile
 
     public class SurviveTheInternetBlock
     {
+        public EnginePreference EnginePreference { get; set; }
         public int MaxRetries { get; set; }
         public float GenTemp { get; set; }
+        public float VoteTemp { get; set; }
 
         public SurviveTheInternetBlock()
         {
+            EnginePreference = EnginePreference.Mix;
             MaxRetries = 5;
             GenTemp = 0.7f;
+            VoteTemp = 0.8f;
         }
     }
 
     public class WordSpudBlock
     {
+        public EnginePreference EnginePreference { get; set; }
         public int MaxRetries { get; set; }
         public float GenTemp { get; set; }
+        public float VoteTemp { get; set; }
         public int VoteDelayMs { get; set; }
+        public bool AllowAiVotes { get; set; }
 
         public WordSpudBlock()
         {
+            EnginePreference = EnginePreference.Chat;
             MaxRetries = 5;
             GenTemp = 0.8f;
+            VoteTemp = 0.8f;
             VoteDelayMs = 1000;
+            AllowAiVotes = true;
         }
     }
 }

--- a/src/config.toml
+++ b/src/config.toml
@@ -1,11 +1,17 @@
 # Changing these settings may cause things to work in unexpected ways. Make sure you're aware of what you're changing!
 
 [general]
-name = "GPT"
+player_name = "GPT"
 logging_level = "information"  # verbose, debug, information, warning, error, fatal
-engine = "davinci-002"
+
+# Note: gpt-4o-mini is cheaper/smarter than davinci-002, but has less varied in responses
+[model]
+completion_engine = "davinci-002"
+chat_engine = "gpt-4o-mini"
+use_chat_engine_for_voting = true
 
 [blather_round]
+engine_preference = "CHAT"  # COMPLETION, CHAT, MIX
 max_retries = 5
 gen_temp = 0.8
 guess_delay_min_ms = 2000
@@ -16,6 +22,7 @@ word_delay_ms = 100
 part_delay_ms = 500
 
 [fibbage]
+engine_preference = "MIX"
 max_retries = 5
 gen_temp = 0.8
 vote_temp = 0.8
@@ -23,17 +30,20 @@ submission_retries = 2
 category_choice_delay_ms = 3000
 
 [joke_boat]
+engine_preference = "MIX"
 max_retries = 5
 gen_temp = 0.8
 vote_temp = 0.8
 max_topic_gen_count = 5
 
 [quiplash]
+engine_preference = "MIX"
 max_retries = 5
 gen_temp = 0.7
 vote_temp = 0.8
 
 [survey_scramble]
+engine_preference = "MIX"
 max_retries = 4
 gen_temp = 0.8
 vote_temp = 0.7
@@ -52,10 +62,15 @@ dash_doubledown_method = "RANDOM"    # WINNING, LOSING, CLOSE, RANDOM
 dash_doubledown_chance = 0.25
 
 [survive_the_internet]
+engine_preference = "MIX"
 max_retries = 5
 gen_temp = 0.7
+vote_temp = 0.8
 
 [word_spud]
+engine_preference = "CHAT"
 max_retries = 5
 gen_temp = 0.8
+vote_temp = 0.8
 vote_delay_ms = 1000
+allow_ai_votes = true


### PR DESCRIPTION
- Individual games can now be set to generate content using chat models, completion models, or both
- Voting requests (i.e. "which of these things is best/funniest/etc") are handled by chat models by default
- Add AI voting to Word Spud and Survive the Internet
- Assorted fixes